### PR TITLE
Update Get-AbrSRMProtectionGroup.ps1

### DIFF
--- a/Src/Private/Get-AbrSRMProtectionGroup.ps1
+++ b/Src/Private/Get-AbrSRMProtectionGroup.ps1
@@ -5,7 +5,7 @@ function Get-AbrSRMProtectionGroup {
     .DESCRIPTION
         Documents the configuration of VMware SRM in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.4.3
+        Version:        0.4.5
         Author:         Jonathan Colon & Tim Carman
         Twitter:        @jcolonfzenpr / @tpcarman
         Github:         @rebelinux / @tpcarman

--- a/Src/Private/Get-AbrSRMProtectionGroup.ps1
+++ b/Src/Private/Get-AbrSRMProtectionGroup.ps1
@@ -5,7 +5,7 @@ function Get-AbrSRMProtectionGroup {
     .DESCRIPTION
         Documents the configuration of VMware SRM in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        0.4.2
+        Version:        0.4.3
         Author:         Jonathan Colon & Tim Carman
         Twitter:        @jcolonfzenpr / @tpcarman
         Github:         @rebelinux / @tpcarman
@@ -83,6 +83,9 @@ function Get-AbrSRMProtectionGroup {
                                                     if ($ProtectionGroup.ListProtectedVMs()) {
                                                         $ProtectedVMs = ConvertTo-VIobject $ProtectionGroup.ListProtectedVMs().vm.MoRef
                                                     }
+                                                    else {
+                                                        $ProtectedVMs = ""
+                                                    }
 
                                                     $inObj = [ordered] @{
                                                         'Name' = $ProtectionGroupInfo.Name
@@ -117,8 +120,14 @@ function Get-AbrSRMProtectionGroup {
                                                     if ($ProtectionGroup.ListProtectedVMs()) {
                                                         $ProtectedVMs = ConvertTo-VIobject $ProtectionGroup.ListProtectedVMs().vm.MoRef
                                                     }
+                                                    else {
+                                                        $ProtectedVMs = ""
+                                                    }
                                                     if ($ProtectionGroup.ListAssociatedVms()) {
                                                         $AssociatedVMs = ConvertTo-VIobject $ProtectionGroup.ListAssociatedVms().MoRef
+                                                    }
+                                                    else {
+                                                        $AssociatedVMs = ""
                                                     }
 
                                                     $inObj = [ordered] @{
@@ -161,6 +170,9 @@ function Get-AbrSRMProtectionGroup {
                                                         if ($ProtectionGroup.ListProtectedVMs()) {
                                                             $ProtectedVMs = ConvertTo-VIobject $ProtectionGroup.ListProtectedVMs().vm.MoRef
                                                         }
+                                                        else {
+                                                            $ProtectedVMs = ""
+                                                        }
 
                                                         if ($ProtectionGroup.ListProtectedDatastores()) {
                                                             $ProtectedDatastores = ConvertTo-VIobject $ProtectionGroup.ListProtectedDatastores().MoRef
@@ -196,6 +208,9 @@ function Get-AbrSRMProtectionGroup {
                                                         Write-PScriboMessage "Discovered Protection Group $($ProtectionGroupInfo.Name)."
                                                         if ($ProtectionGroup.ListProtectedVMs()) {
                                                             $ProtectedVMs = ConvertTo-VIobject $ProtectionGroup.ListProtectedVMs().vm.MoRef
+                                                        }
+                                                        else {
+                                                            $ProtectedVMs = ""
                                                         }
 
                                                         if ($ProtectionGroup.ListProtectedDatastores()) {
@@ -247,6 +262,9 @@ function Get-AbrSRMProtectionGroup {
                                                 if ($ProtectionGroups) {
                                                     if ($ProtectionGroup.ListProtectedVMs()) {
                                                         $ProtectedVMs = $ProtectionGroup.ListProtectedVMs()
+                                                    }
+                                                    else {
+                                                        $ProtectedVMs = ""
                                                     }
                                                     if ($InfoLevel.ProtectionGroup -eq 2) {
                                                         foreach ($ProtectedVM in $ProtectedVMs) {


### PR DESCRIPTION
Fixed issue where if a protection group was not protecting any VMs, it would list the VMs in the previous protection group in the output.

## Description

If a protection group had protected VMs, the script would assign that value to $ProtectedVMs
If there was no protected VMs in a protection group, the script would not change the value.
So for our empty protection groups, we were getting the list of protected VMs from the previous protection group in the loop.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
We were incorrectly getting duplicate VMs listed as protected in multiple protection groups in the report

## How Has This Been Tested?
This has been tested in a dev testbed, on Windows Server 2019 with PowerCLI 13.1.0.21624340, running against VMWare SRM 8.
Its a simple change in code, and has no impact on other areas of the script.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
