### PR TITLE
v0.4.5 public release

### DIFF
--- a/AsBuiltReport.VMware.SRM.psd1
+++ b/AsBuiltReport.VMware.SRM.psd1
@@ -12,7 +12,7 @@
 RootModule = 'AsBuiltReport.VMware.SRM.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.4.4'
+ModuleVersion = '0.4.5'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # :arrows_clockwise: VMware SRM As Built Report Changelog
 
+## [0.4.5] - 2023-11-09
+
+### Fixed
+
+- Fix issue where if a protection group was not protecting any VMs, it would list the VMs in the previous protection group in the output. @flynngw
+
 ## [0.4.4] - 2023-08-25
 
 ### Fixed

--- a/Src/Private/Get-AbrSRMRecoveryPlan.ps1
+++ b/Src/Private/Get-AbrSRMRecoveryPlan.ps1
@@ -169,7 +169,7 @@ function Get-AbrSRMRecoveryPlan {
                                                 $TableParams = @{
                                                     Name = "VM Recovery Settings - $($VM.VmName)"
                                                     List = $False
-                                                    ColumnWidths = 16, 10, 12, 12, 12, 12, 12, 14s
+                                                    ColumnWidths = 16, 10, 12, 12, 12, 12, 12, 14
                                                 }
                                                 if ($Report.ShowTableCaptions) {
                                                     $TableParams['Caption'] = "- $($TableParams.Name)"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

### [0.4.5] - 2023-11-09

#### Fixed

- Fix issue where if a protection group was not protecting any VMs, it would list the VMs in the previous protection group in the output. @flynngw

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- HomeLab

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
